### PR TITLE
snap: align with 22

### DIFF
--- a/.github/workflows/close-snap.yml
+++ b/.github/workflows/close-snap.yml
@@ -1,0 +1,19 @@
+name: Close Snaps
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  close:
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 5
+
+    steps:
+    - name: Close obsolete channels
+      uses: canonical/actions/close-snap@release
+      continue-on-error: true
+      with:
+        channel: 20/edge/pr${{ github.event.number }}
+        snapcraft-token: ${{ secrets.SNAPCRAFT_TOKEN }}

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -12,15 +12,6 @@ jobs:
 
     timeout-minutes: 30
 
-    strategy:
-      matrix:
-        platform:
-        - amd64
-        - armhf
-        - arm64
-        - ppc64el
-        # Broken: - s390x
-
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -28,9 +19,8 @@ jobs:
         fetch-depth: 0  # needed for version determination
 
     - name: Build and publish the snap
-      uses: canonical/actions/build-snap@multiarch
+      uses: canonical/actions/build-snap@release
       with:
-        architecture: ${{ matrix.platform }}
         snapcraft-token: ${{ secrets.SNAPCRAFT_TOKEN }}
         publish: ${{ github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name }}
         publish-channel: 20/edge/pr${{ github.event.number }}

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,0 +1,36 @@
+name: Snap
+
+on:
+  merge_group:
+    types: [checks_requested]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  Snap:
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 30
+
+    strategy:
+      matrix:
+        platform:
+        - amd64
+        - armhf
+        - arm64
+        - ppc64el
+        # Broken: - s390x
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0  # needed for version determination
+
+    - name: Build and publish the snap
+      uses: canonical/actions/build-snap@multiarch
+      with:
+        architecture: ${{ matrix.platform }}
+        snapcraft-token: ${{ secrets.SNAPCRAFT_TOKEN }}
+        publish: ${{ github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name }}
+        publish-channel: 20/edge/pr${{ github.event.number }}

--- a/glue/glmark2-wayland-wrapper
+++ b/glue/glmark2-wayland-wrapper
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec glmark2-es2-wayland --data-path ${SNAP}/usr/share/glmark2 "$@"

--- a/scripts/bin/setup.sh
+++ b/scripts/bin/setup.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+
+SNAP_INSTANCE_NAME="$(readlink -f $0 | cut -f 3 -d /)"
+
+snap_connect_harder() {
+  # Note the available slot providers
+  if ! snap connections ${SNAP_INSTANCE_NAME} | grep --quiet "^content.*${SNAP_INSTANCE_NAME}:$1.*$"; then
+    available_providers="$(snap interface "$1" | sed -e '1,/slots:/d')"
+  else
+    available_providers="$(snap interface content | sed -e '1,/slots:/d' | grep "$1")"
+  fi
+
+  # For wayland try some well known providers
+  if [ "wayland" = "$1" ]; then
+    for PROVIDER in ubuntu-frame mir-kiosk; do
+       if echo "$available_providers" | grep --quiet "\- ${PROVIDER}"; then
+         sudo snap connect "${SNAP_INSTANCE_NAME}:$1" "${PROVIDER}:$1"
+         return 0
+       fi
+    done
+  fi
+
+  echo "Warning: Failed to connect '$1'. Please connect manually, available providers are:\n$available_providers"
+}
+
+for PLUG in opengl wayland x11; do
+  if ! snap connections ${SNAP_INSTANCE_NAME} | grep --quiet "^.*${SNAP_INSTANCE_NAME}:${PLUG}.*${PLUG}.*$"; then
+    sudo snap connect "${SNAP_INSTANCE_NAME}:${PLUG}" 2> /dev/null || snap_connect_harder ${PLUG}
+  fi
+done

--- a/scripts/bin/wayland-launch
+++ b/scripts/bin/wayland-launch
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+for PLUG in opengl wayland x11; do
+  if ! snapctl is-connected ${PLUG}
+  then
+    echo "WARNING: ${PLUG} interface not connected! Please run: /snap/${SNAP_INSTANCE_NAME}/current/bin/setup.sh"
+  fi
+done
+
+real_xdg_runtime_dir=$(dirname "${XDG_RUNTIME_DIR}")
+real_wayland=${real_xdg_runtime_dir}/${WAYLAND_DISPLAY:-wayland-0}
+
+[ -d "${real_xdg_runtime_dir}" ] || echo "WARNING: missing ${real_xdg_runtime_dir}, is a Wayland compositor running?"
+[ -O "${real_wayland}" ] || echo "WARNING: missing ${real_wayland}, is a Wayland compositor running?"
+
+if mkdir -p "$XDG_RUNTIME_DIR" -m 700; then
+  ln -sf "${real_wayland}" "$XDG_RUNTIME_DIR"
+  ln -sf "${real_wayland}.lock" "$XDG_RUNTIME_DIR"
+else
+  echo "WARNING: XDG_RUNTIME_DIR ($XDG_RUNTIME_DIR) missing, Wayland will not work"
+fi
+
+exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,20 +3,43 @@ version: "20.04"
 base: core20
 summary: Tools helpful in debugging graphics stacks
 description: |
-  - drm-info:
+  - drm-info (MIT):
     List the capabilities and current settings of this device's DRM
     (Direct Rendering Manager) hardware.
-  - glmark2-es2-wayland:
+  - glmark2-es2 (GPLv3):
+    OpenGL ES 2.0 X11 benchmark.
+  - glmark2-es2-wayland (GPLv3):
     OpenGL ES 2.0 Wayland benchmark.
-  - eglinfo:
+  - eglinfo (MIT):
     Dump information about the available EGL setup.
+  - glxinfo (MIT):
+    Dump information about the available GLX setup.
+  - kmscube (MIT):
+    Example KMS/GBM/EGL application
+  - vainfo (MIT):
+    Dump information about the available VAAPI (hardware video acceleration) setup.
+  - vdpauinfo (MIT):
+    Dump information about the available VDPAU (hardware video acceleration) setup.
+  - vulkaninfo (Apache-2.0):
+    Dump information about the available Vulkan setup.
+  - vkcube (Apache-2.0):
+    Test the Vulkan setup.
+
+  This snap uses the graphics-core20 interface to gain support graphics hardware.
+  It can be used to verify custom graphics-core20 provider implementations.
+
+  See https://mir-server.io/docs/the-graphics-core20-snap-interface) for more
+  information.
+website: https://github.com/MirServer/graphics-test-tools
+contact: https://github.com/MirServer/graphics-test-tools/issues
+license: Apache-2.0 AND GPL-3.0 AND MIT
 
 grade: stable
 confinement: strict
 
 environment:
   # Setup EGL from the plugs
-  LD_LIBRARY_PATH:    $SNAP/graphics/lib
+  LD_LIBRARY_PATH:    $SNAP/graphics/lib:$SNAP/usr/local/lib
   LIBGL_DRIVERS_PATH: $SNAP/graphics/dri
   __EGL_VENDOR_LIBRARY_DIRS: $SNAP/graphics/glvnd/egl_vendor.d
 
@@ -42,9 +65,16 @@ apps:
     plugs:
       - opengl
       - wayland
+      - x11
     command-chain:
       - bin/wayland-launch
     command: usr/bin/eglinfo
+
+  glmark2-es2:
+    plugs:
+      - opengl
+      - x11
+    command: usr/bin/glmark2-es2 --data-path $SNAP/usr/share/glmark2
 
   glmark2-es2-wayland:
     plugs:
@@ -52,19 +82,48 @@ apps:
       - wayland
     command-chain:
       - bin/wayland-launch
-    command: glmark2-wayland-wrapper
+    command: usr/bin/glmark2-es2-wayland --data-path $SNAP/usr/share/glmark2
+
+  glxinfo:
+    plugs:
+      - opengl
+      - x11
+    command: usr/bin/glxinfo
+
+  kmscube:
+    plugs:
+      - opengl
+    command: usr/bin/kmscube
+
+  vainfo:
+    plugs:
+      - opengl
+    command: usr/bin/vainfo
+
+  vdpauinfo:
+    plugs:
+      - opengl
+      - x11
+    command: usr/bin/vdpauinfo
+
+  vulkaninfo:
+    plugs:
+      - opengl
+      - x11
+    command: usr/bin/vulkaninfo
+
+  vkcube:
+    plugs:
+      - opengl
+      - x11
+    command: usr/bin/vkcube
 
 parts:
-  glue:
+  scripts:
     plugin: dump
-    source: glue
-
-  mir-kiosk-snap-launch:
-      plugin: dump
-      source: https://github.com/MirServer/mir-kiosk-snap-launch.git
-      override-build:  $SNAPCRAFT_PART_BUILD/build-with-plugs.sh opengl wayland
-      stage-packages:
-        - inotify-tools
+    source: scripts
+    stage-packages:
+      - inotify-tools
 
   drm-info:
     plugin: meson
@@ -78,7 +137,6 @@ parts:
       meson subprojects download --sourcedir ${SNAPCRAFT_PART_SRC}
       snapcraftctl build
     stage-packages:
-      - drm-info
       - libpci3
 
   eglinfo:
@@ -91,10 +149,43 @@ parts:
     plugin: nil
     source: .
     stage-packages:
+      - glmark2-es2
       - glmark2-es2-wayland
 
+  glxinfo:
+    plugin: nil
+    stage-packages:
+      - mesa-utils
+
+  kmscube:
+    plugin: nil
+    stage-packages:
+      - kmscube
+
+  vainfo:
+    plugin: nil
+    stage-packages:
+      - vainfo
+
+  vdpauinfo:
+    plugin: nil
+    stage-packages:
+      - vdpauinfo
+
+  vulkan-tools:
+    plugin: nil
+    stage-packages:
+      - vulkan-tools
+
   cleanup:
-    after: [drm-info, eglinfo, glmark2]
+    after:
+      - drm-info
+      - eglinfo
+      - glmark2
+      - kmscube
+      - vainfo
+      - vdpauinfo
+      - vulkan-tools
     plugin: nil
     build-snaps: [ mesa-core20 ]
     override-prime: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -68,16 +68,17 @@ parts:
 
   drm-info:
     plugin: meson
-    source: https://github.com/ascent12/drm_info.git
-    source-tag: v2.3.0
+    source: https://gitlab.freedesktop.org/emersion/drm_info.git
+    source-tag: v2.5.0
     build-packages:
       - meson
-      - libdrm-dev
-      - libjson-c-dev
       - libpci-dev
       - pkg-config
+    override-build: |
+      meson subprojects download --sourcedir ${SNAPCRAFT_PART_SRC}
+      snapcraftctl build
     stage-packages:
-      - libdrm2
+      - drm-info
       - libpci3
 
   eglinfo:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -128,15 +128,16 @@ parts:
   drm-info:
     plugin: meson
     source: https://gitlab.freedesktop.org/emersion/drm_info.git
-    source-tag: v2.5.0
+    source-tag: v2.3.0
     build-packages:
-      - meson
+      - libdrm-dev
+      - libjson-c-dev
       - libpci-dev
+      - meson
       - pkg-config
-    override-build: |
-      meson subprojects download --sourcedir ${SNAPCRAFT_PART_SRC}
-      snapcraftctl build
     stage-packages:
+      - libdrm2
+      - libjson-c4
       - libpci3
 
   eglinfo:


### PR DESCRIPTION
This brings all the additional tools from g-t-t/22 aligning it better for backporting, and refreshes drm-info.

Because the contract between graphics-core20 providers and consumers isn't as strong, some of these may not work, depending on the provider.